### PR TITLE
docs: fix incorrect AWSIM repo URL in Unity setup instructions

### DIFF
--- a/docs/GettingStarted/SetupUnityProject/index.md
+++ b/docs/GettingStarted/SetupUnityProject/index.md
@@ -81,7 +81,7 @@ To open the Unity AWSIM project in Unity Editor:
 === "Using Unity Hub"
     1. Make sure you have the AWSIM repository cloned and ROS 2 is not sourced.
         ```
-        git clone git@github.com:autowarefoundation/AWSIM.git
+        git clone git@github.com:autowarefoundation/AWSIM-Labs.git
         ```
 
     2. Launch UnityHub.


### PR DESCRIPTION
## Description

Fixes an incorrect repository URL in the Unity Hub setup instructions.
The docs previously pointed to autowarefoundation/AWSIM.git, but the correct repository is autowarefoundation/AWSIM-Labs.git.